### PR TITLE
#33 tango-doc-33 Update documentation tutorial with missing commands

### DIFF
--- a/source/tutorials/documentation-workflow-tutorial.rst
+++ b/source/tutorials/documentation-workflow-tutorial.rst
@@ -25,18 +25,14 @@ If you have prerequisites installed, you need to install Sphinx tools:
    :command:`virtualenv doc-env`
 #. Activate the environment:
 
-   :command:`. doc-env/bin/activate` or :command:`source doc-env/bin/activate`
+   :command:`source doc-env/bin/activate`
 #. Install Sphinx:
 
    :command:`pip install sphinx`
-    .. note::
-        If you're using a Unix-based system, you might need to use :command:`sudo pip install sphinx`.
 
 #. Install Breathe (a module to deal with Doxygen C++ API documentation):
 
    :command:`pip install breathe`
-    .. note::
-        If you're using a Unix-based system, you might need to use :command:`sudo pip install breathe`.
 
 Get documentation sources
 -------------------------

--- a/source/tutorials/documentation-workflow-tutorial.rst
+++ b/source/tutorials/documentation-workflow-tutorial.rst
@@ -4,47 +4,47 @@ Documentation workflow tutorial
 Prerequisites
 -------------
 
-To work with documentation, first you need to have installed on your system:
+To work with documentation, first you need to have the following programs installed on your system:
 
-- :program:`Python` >= 2.7 as Sphinx is a Python tool.
-- :program:`Git` since the sources are kept in a git repository.
+- :program:`Python` >= 2.7 (as Sphinx is a Python tool),
+- :program:`Git` (since the sources are kept in a git repository).
 
 Sphinx installation
 -------------------
 
-If you have a prerequisities installed, you need to install Sphinx tools:
+If you have prerequisites installed, you need to install Sphinx tools:
 
-#. Install virtual environments support for python:
+#. Install virtual environments support for Python:
 
    :command:`pip install virtualenv`
     .. note::
-        If you're using a Unix-based system, you might need to use :command:`sudo`.
+        If you're using a Unix-based system, you might need to use :command:`sudo pip install virtualenv`.
 
 #. Create an environment for sphinx tools:
 
    :command:`virtualenv doc-env`
 #. Activate the environment:
 
-   :command:`. doc-env/bin/activate`
+   :command:`. doc-env/bin/activate` or :command:`source doc-env/bin/activate`
 #. Install Sphinx:
 
    :command:`pip install sphinx`
     .. note::
-        If you're using a Unix-based system, you might need to use :command:`sudo`.
+        If you're using a Unix-based system, you might need to use :command:`sudo pip install sphinx`.
 
-#. Install Breathe (a module to deal with doxygen C++ API documenatation):
+#. Install Breathe (a module to deal with Doxygen C++ API documentation):
 
    :command:`pip install breathe`
     .. note::
-        If you're using a Unix-based system, you might need to use :command:`sudo`.
+        If you're using a Unix-based system, you might need to use :command:`sudo pip install breathe`.
 
 Get documentation sources
 -------------------------
 
-#. Go to the some folder where we keep sourcecode
+#. Go to a folder where you keep sources:
 
    :command:`cd src`
-#. Clone documentation from the repository
+#. Clone documentation from the repository:
 
    :command:`git clone https://github.com/tango-controls/tango-doc.git`
 #. Change current folder to the documentation folder:
@@ -53,38 +53,38 @@ Get documentation sources
 #. Try to build the documentation:
 
    :command:`sphinx-build source build`
-#. Open build/index.html with your favorite browser to see if it has been built correctly
+#. Open build/index.html with your favorite browser to see if it has been built correctly.
 
 .. _updating-doc:
 
 Updating documentation
 ----------------------
 
-#. Create your local working branch
+#. Create your local working branch:
 
    .. note::
 
-      The following command creates a branch based on the current branch you are. If you just started the tutorial
-      it is `master`. If you would like to contribute to other branch, like directly to `9.2.5`, you need to check it
+      The following command creates a branch based on the current branch you are on. If you've just started the tutorial
+      it is `master`. If you would like to contribute to another branch, e.g. directly to `9.2.5`, you need to check it
       out first: :command:`git checkout origin/9.2.5`
 
-      To see what what branch is the current one please call: :command:`git branch -a`. The current branch is marked
-      with asterisk (\*).
+      To see what what branch is the current one use: :command:`git branch -a`. The current branch is marked
+      with an asterisk (\*).
 
    :command:`git checkout -b "TD-66-step-by-step-demo"`
 
-#. Edit (or create if it does not exist) a file you would like to edit. If you are following this tutorial for learning
-   please use the file: :file:`source/tutorials/example.rst`
+#. Edit a file (or create it if it doesn't exist) you would like to change. If you are following this tutorial for learning
+   please use this file: :file:`source/tutorials/example.rst`
 
-#. Make sure that file appears in a relevant toc-tree (in some :file:`index.rst` file or
+#. Make sure that the file appears in a relevant toc-tree (in some :file:`index.rst` file or
    in :file:`source/contents.rst`). If you are now learning please check :file:`source/tutorials/index.rst`
 
-#. Check if your changes build correctly
+#. Check if your changes have built correctly:
 
    :command:`sphinx-build source build`
-#. Check result with a browser. If you are doing learn steps open :file:`build/tutorials/index.html`
+#. Check results with a browser. If you've edited the example, open :file:`build/tutorials/index.html`
 
-If everything is ok you may commit changes  and send a pull request (ask to review and merge into an on-line branch).
+If everything is OK, you may commit changes and send a pull request (ask to review and merge into an on-line branch).
 
 Committing changes
 ------------------
@@ -95,7 +95,7 @@ Committing changes
 
    :command:`git add source/tutorials/index.rst`
 
-#. Commit the changes providing some meaning full message. For example:
+#. Commit the changes providing some meaningful message. For example:
 
    :command:`git commit -m "doing tutorial"`
 
@@ -113,7 +113,7 @@ Committing changes
 
    .. note::
 
-      If you are contributing to other branch than `master` , for example directly to the `9.5.2` version you need to
+      If you are contributing to other branch than `master`, for example directly to the `9.5.2`, you need to
       call :command:`git rebase 9.5.2`
 
 Pushing (to the GitHub repository)
@@ -123,7 +123,7 @@ Pushing (to the GitHub repository)
 
    :command:`git push -u origin TD-66-step-by-step-demo`
 
-Now you are ready to ask for merging by sending a pull request on the GitHub. To to this for this:
+Now you are ready to ask for merging by sending a pull request on GitHub.
 
 Pull request (asking for merge)
 -------------------------------
@@ -138,19 +138,19 @@ Pull request (asking for merge)
 
 #. Provide a relevant comment and click :guilabel:`Create pull request`.
 
-Now, someone will review your contribution, merge into selected branch and publish. If he find some issues he will
-get back to you.
+Now, someone will review your contribution, merge into selected branch and publish. If he/she finds some issues,
+he/she will get back to you.
 
 Continuing the contribution
 ---------------------------
 
-If you would like to come with some other contribution you do not need to clone sources again. Follow the following
+If you would like to come up with some other contribution, you do not need to clone sources again. Follow the following
 steps:
 
 #. Fetch changes from the origin repository:
 
    :command:`git fetch origin`
-#. Switch to main branch you are going to update (for example 9.2.5):
+#. Switch to the main branch you are going to update (for example 9.2.5):
 
    :command:`git checkout origin/9.2.5`
 
@@ -159,4 +159,3 @@ steps:
    :command:`git pull`
 
 #. Follow steps from :ref:`Updating documentation <updating-doc>`
-

--- a/source/tutorials/documentation-workflow-tutorial.rst
+++ b/source/tutorials/documentation-workflow-tutorial.rst
@@ -17,6 +17,9 @@ If you have a prerequisities installed, you need to install Sphinx tools:
 #. Install virtual environments support for python:
 
    :command:`pip install virtualenv`
+    .. note::
+        If you're using a Unix-based system, you might need to use :command:`sudo`.
+
 #. Create an environment for sphinx tools:
 
    :command:`virtualenv doc-env`
@@ -26,13 +29,14 @@ If you have a prerequisities installed, you need to install Sphinx tools:
 #. Install Sphinx:
 
    :command:`pip install sphinx`
+    .. note::
+        If you're using a Unix-based system, you might need to use :command:`sudo`.
+
 #. Install Breathe (a module to deal with doxygen C++ API documenatation):
 
-   :command:`pip install --upgrade git+git://github.com/michaeljones/breathe@cc8f830`
-
-   .. note::
-
-      There is a fixed version from git that has been tested to work
+   :command:`pip install breathe`
+    .. note::
+        If you're using a Unix-based system, you might need to use :command:`sudo`.
 
 Get documentation sources
 -------------------------
@@ -68,6 +72,7 @@ Updating documentation
       with asterisk (\*).
 
    :command:`git checkout -b "TD-66-step-by-step-demo"`
+
 #. Edit (or create if it does not exist) a file you would like to edit. If you are following this tutorial for learning
    please use the file: :file:`source/tutorials/example.rst`
 
@@ -89,17 +94,18 @@ Committing changes
    :command:`git add source/tutorials/example.rst`
 
    :command:`git add source/tutorials/index.rst`
+
 #. Commit the changes providing some meaning full message. For example:
 
    :command:`git commit -m "doing tutorial"`
 
    .. note::
 
-      The changes are now committed to your local repository. To share them you need to push. You may repeat
+      The changes are now committed to your local repository. To share them, you need to push. You may repeat
       editing, checking and commit steps several times without pushing util you are happy with your work. This
       way you may track the history of changes.
 
-#. If your work took a long time it is good to do  rebasing with recent changes done by someone else. For example:
+#. If your work took a long time it is good to do rebasing with recent changes done by someone else. For example:
 
    :command:`git fetch origin`
 
@@ -143,9 +149,14 @@ steps:
 
 #. Fetch changes from the origin repository:
 
-   :command:`git fetch`
+   :command:`git fetch origin`
 #. Switch to main branch you are going to update (for example 9.2.5):
 
    :command:`git checkout origin/9.2.5`
+
+#. Pull the changes:
+
+   :command:`git pull`
+
 #. Follow steps from :ref:`Updating documentation <updating-doc>`
 

--- a/source/tutorials/documentation-workflow-tutorial.rst
+++ b/source/tutorials/documentation-workflow-tutorial.rst
@@ -17,8 +17,9 @@ If you have prerequisites installed, you need to install Sphinx tools:
 #. Install virtual environments support for Python:
 
    :command:`pip install virtualenv`
-    .. note::
-        If you're using a Unix-based system, you might need to use :command:`sudo pip install virtualenv`.
+
+   .. note::
+      If you're using a Unix-based system, you might need to use :command:`sudo pip install virtualenv`.
 
 #. Create an environment for sphinx tools:
 
@@ -105,7 +106,7 @@ Committing changes
 
    :command:`git fetch origin`
 
-   :command:`git rebase master`
+   :command:`git rebase origin/master`
 
    .. note::
 


### PR DESCRIPTION
Fixes #33
I've added notes to specify that sudo might have to be used, corrected git commands and changed version of breathe.