### PR TITLE
fixing misspell in tutorials and how-tos title

### DIFF
--- a/source/tutorials-and-howtos/index.rst
+++ b/source/tutorials-and-howtos/index.rst
@@ -1,4 +1,4 @@
-Tutorials nad How-Tos
+Tutorials and How-Tos
 =====================
 
 .. toctree::


### PR DESCRIPTION
@andygotz found a misspell which is corrected by this commit.