### PR TITLE
Moved maps from ecosystem to the relevant sections.

### DIFF
--- a/source/administration/index.rst
+++ b/source/administration/index.rst
@@ -7,6 +7,7 @@ Administration
    :name: administrationtoc
    :maxdepth: 2
 
+   overview
    deployment/index
    services/index
    maintenance/index

--- a/source/administration/overview.rst
+++ b/source/administration/overview.rst
@@ -1,0 +1,13 @@
+.. _administrators_overview:
+
+Overview
+=========
+
+As soon as a Tango system grows to over a few devices and servers it needs to be administered.
+A number of tools have been developed to administer a Tango control system.
+
+This clickable map gives and overview of the administrative tools.
+
+..  raw:: html
+
+    <embed width="110%" height="600px" type="text/html" src="../_static/layer-map-source/tango_administration_map.html">

--- a/source/development/index.rst
+++ b/source/development/index.rst
@@ -8,6 +8,7 @@ The section is organized as follows:
    :name: developersguidetoc
    :maxdepth: 2
 
+   overview
    general-guidelines/index
    corba
    client-api/index

--- a/source/development/overview.rst
+++ b/source/development/overview.rst
@@ -1,0 +1,25 @@
+.. _developers_overview:
+
+Overview
+=========
+
+Tango is a developers toolkit. There are many libraries and tools for implemented device clients and servers.
+
+C++ and Python
+---------------
+
+This clickable map shows the libraries and tools available for C++ and Python developers.
+
+..  raw:: html
+
+    <embed width="200%" height="600px" type="text/html" src="../_static/layer-map-source/tango_control_system_cpp_python_development.html">
+
+Java
+-----
+
+This clickable map shows the libraries and tools available for Java developers.
+
+..  raw:: html
+
+    <embed width="200%" height="600px" type="text/html" src="../_static/layer-map-source/tango_control_system_java_development.html">
+

--- a/source/overview/ecosystem.rst
+++ b/source/overview/ecosystem.rst
@@ -1,51 +1,23 @@
-Tango Ecosystem
-================
+Ecosystem
+==========
 
-The Tango ecosystem has developed over a decade now and offers a rich ecosystem for developers and clients
-alike.
+The Tango ecosystem offers a rich ecosystem for developers and clients alike.
 The ecosystem is best appreciated via these maps which show what exists and where it is situated in the software stack.
-Use the :ref:`key` to understand the colour code used.
+Use the :ref:`map key <map_key>` to understand the colour code used.
 
-Developers Tools
------------------
-Tango is a developers toolkit. There are many libraries and tools for implemented device clients and servers.
+Tango is a developers toolkit. There are many libraries and tools for implemented device 
+clients and servers.
+Refer to the :ref:`developers guide map <developers_overview>` for a quick overview.
 
-..  raw:: html
-
-    <embed width="200%" height="600px" type="text/html" src="../_static/layer-map-source/tango_control_system_development.html">
-
-Administrating Tools
----------------------
-Tango is designed to run smal and large systems. In order to facilitate managing large systems a number
+Tango is designed to run small and large systems. In order to facilitate managing large systems a number
 of administrative tools are provided.
+Refer to the :ref:`administrators map <administrators_overview>` for a quick overview.
 
-..  raw:: html
-
-    <embed width="110%" height="600px" type="text/html" src="../_static/layer-map-source/tango_administration_map.html">
-
-Archiving Tools
-----------------
 All control systems need to be able archive data so they can look back at past data. Tango comes with a number
 of archiving solutions.
+Refer to the :ref:`archiving map <archiving_overview>` for a quick overview.
 
-..  raw:: html
-
-    <embed width="100%" height="600px" type="text/html" src="../_static/layer-map-source/tango_archiving_map.html">
-
-Bindings
----------
-Tango offers a wide range of bindings to different languages.
-
-..  raw:: html
-
-    <embed width="100%" height="600px" type="text/html" src="../_static/layer-map-source/tango_bindings_map.html">
-
-.. _Key:
-
-Key
-----
-The key to the colour codes of the layered maps.
-
-..  raw:: html
-
-    <embed width="100%" height="650px" type="text/html" src="../_static/layer-map-source/tango_key.html">
+In addition to the rich Python, C++ and Java api's for Tango a number of other languages
+can be used with the help of one of the many bindings for Tango.
+Refer to the :ref:`bindings map <bindings_overview>` for a quick overview of the 
+known bindings.

--- a/source/overview/index.rst
+++ b/source/overview/index.rst
@@ -3,9 +3,8 @@
 .. image:: ../img/logo_tangocontrols.png
     :align: center
 
-Tango Overview
-==============
-
+Overview
+=========
 
 Contents:
 

--- a/source/reference/index.rst
+++ b/source/reference/index.rst
@@ -4,6 +4,7 @@ Reference
 .. toctree::
    :name: referencetoc
 
+   map_key
    glossary
    bibliography
 

--- a/source/reference/map_key.rst
+++ b/source/reference/map_key.rst
@@ -1,0 +1,17 @@
+.. _map_key:
+
+Map Key
+=========
+
+The color coded key for the clickable maps of the Tango ecosystem.
+
+..  raw:: html
+
+    <embed width="200%" height="600px" type="text/html" src="../_static/layer-map-source/tango_key.html">
+
+
+Acknowledgements
+-----------------
+
+The maps were originally produced by Lajos Fülöp (ELI-ALPS) and have been updated and
+formatted for this document by Stuart James (ESRF).

--- a/source/tools-and-extensions/archiving/overview.rst
+++ b/source/tools-and-extensions/archiving/overview.rst
@@ -1,0 +1,18 @@
+.. _archiving_overview:
+
+Overview
+=========
+
+Tango has two main archiving solutions - the original one (HDB) and a new one (HDB++). 
+The difference between the two is in the features.
+HDB supports Oracle and MySQL databases.
+HDB++ supports higher time resolution, multiple database backends (MySQL and Cassandra), 
+and is based on events.
+HDB++ is designed to have a higher throughput and a number of improvements like
+better error management, lower footprint etc.
+
+This map shows you how the archiving systems and the related tools are layered. 
+
+..  raw:: html
+
+    <embed width="100%" height="600px" type="text/html" src="../../_static/layer-map-source/tango_archiving_map.html">

--- a/source/tools-and-extensions/bindings/overview.rst
+++ b/source/tools-and-extensions/bindings/overview.rst
@@ -1,0 +1,15 @@
+.. _bindings_overview:
+
+Overview
+=========
+
+Tango has a number of bindings to other languages and tools. 
+This clickable map shows you how the known bindings.
+
+..  raw:: html
+
+    <embed width="100%" height="600px" type="text/html" src="../../_static/layer-map-source/tango_bindings_map.html">
+
+There may be others - ask on the forum if 
+you need a binding which is not listed here or would like to publish a binding you
+have written. 

--- a/source/tools-and-extensions/index.rst
+++ b/source/tools-and-extensions/index.rst
@@ -27,7 +27,8 @@ Archiving
 .. toctree::
    :maxdepth: 2
    :name: archivingtoc
-
+   
+   archiving/overview
    archiving/HDB
    archiving/HDB++
 
@@ -56,6 +57,7 @@ Bindings
    :name: bindingstoc
    :maxdepth: 1
 
+   bindings/overview
    bindings/c-lang
    bindings/matlab-and-octave
    bindings/labVIEW


### PR DESCRIPTION
Following Igor's suggestion I have moved the layered maps to the relevant sections and linked to them from the ecosystem section in the overview. This PR fixes this #120 issue.