### PR TITLE
Adding missing states into Glossary in comparison with DS Guideline.

### DIFF
--- a/source/reference/glossary.rst
+++ b/source/reference/glossary.rst
@@ -77,8 +77,7 @@ Glossary
         a piece of equipment it interfaces with or be determined in other way. The behaviour is defined by the
         :term:`device class` which implements a :term:`state machine`. The state may define attributes', commands' and
         pipes' operations available at the moment. Tango Controls limits a set of states the device may be in to 11:
-        ON, OFF, CLOSE, OPEN, INSERT, EXTRACT, MOVING, STANDBY, FAULT, INIT, RUNNING, ALARM,
-DISABLE, UNKNOWN
+        ON, OFF, CLOSE, OPEN, INSERT, EXTRACT, MOVING, STANDBY, FAULT, INIT, RUNNING, ALARM, DISABLE, and UNKNOWN.
 
     state machine
        A state machine for a :term:`device class` defines operations (commands', attributes' and pipes' access) available

--- a/source/reference/glossary.rst
+++ b/source/reference/glossary.rst
@@ -77,7 +77,8 @@ Glossary
         a piece of equipment it interfaces with or be determined in other way. The behaviour is defined by the
         :term:`device class` which implements a :term:`state machine`. The state may define attributes', commands' and
         pipes' operations available at the moment. Tango Controls limits a set of states the device may be in to 11:
-        ON, OFF, RUNNING, OPEN, CLOSE, INSERT, EXTRACT, INIT, ALARM, FAULT and UNKNOWN.
+        ON, OFF, CLOSE, OPEN, INSERT, EXTRACT, MOVING, STANDBY, FAULT, INIT, RUNNING, ALARM,
+DISABLE, UNKNOWN
 
     state machine
        A state machine for a :term:`device class` defines operations (commands', attributes' and pipes' access) available


### PR DESCRIPTION
There was 11 states into Glossary in comparison to 14 into
https://github.com/tango-controls/tango-doc/blob/master/source/development/device-api/ds-guideline/device-server-guidelines.rst#state-transitions