### PR TITLE
Fix displaced text in PDF output

### DIFF
--- a/source/tools-and-extensions/jive/collection.rst
+++ b/source/tools-and-extensions/jive/collection.rst
@@ -12,7 +12,6 @@ Displaying collection
 :audience:`administrators, developers`
 
 .. figure:: collection_view.jpg
-   :align:   left
 
 |clearfloat|
 


### PR DESCRIPTION
Fixes #196.
The problem was caused by `:align: left` directive in the last (in order of appearance in the PDF document) figure of Jive documentation. I'm not exactly sure why, but removing it solves the issue, while not disrupting HTML output too much.