### PR TITLE
Typo correction in astor documentation

### DIFF
--- a/source/tools-and-extensions/built-in/astor/config.rst
+++ b/source/tools-and-extensions/built-in/astor/config.rst
@@ -14,7 +14,7 @@ Click on :menuselection:`File --> Ctrl System Preferences` menu to open
 |                                      | -  :ref:`Multi Tango Host. <known_hosts>`                    |
 |                                      | -  :ref:`Host remote loggin command. <remote_logging>`       |
 |                                      | -  :ref:`Host remote loggin user. <remote_user>`             |
-|                                      | -  :ref:`Jive in RAD_ONLY mode. <jive_mode>`                 |
+|                                      | -  :ref:`Jive in READ_ONLY mode. <jive_mode>`                 |
 |                                      | -  :ref:`Starter starts servers at startup <starter_start>`  |
 +--------------------------------------+--------------------------------------------------------------+
 


### PR DESCRIPTION
RAD_ONLY -> READ_ONLY

Hi @PhilLAL, I have found this correction done to dev branch which is no longer in use. I will merge it to master and close the branch. Thanks!