### PR TITLE
.vscode/ in gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,5 @@
 *.pyc
 .idea/
 build/
+.vscode/
 


### PR DESCRIPTION
This is to prevent including Visual Studio Code project files. 