### PR TITLE
Fix: wrap long tables instead of showing scroll

### DIFF
--- a/source/_static/css/theme_overrides.css
+++ b/source/_static/css/theme_overrides.css
@@ -1,0 +1,13 @@
+/* override table width restrictions */
+@media screen and (min-width: 767px) {
+
+    .wy-table-responsive table td {
+       /* !important prevents the common CSS stylesheets from overriding
+          this as on RTD they are loaded after this stylesheet */
+       white-space: normal !important;
+    }
+ 
+    .wy-table-responsive {
+       overflow: visible !important;
+    }
+ }

--- a/source/conf.py
+++ b/source/conf.py
@@ -219,7 +219,8 @@ if True:  #
            # 'https://media.readthedocs.org/css/sphinx_rtd_theme.css',
            # 'https://media.readthedocs.org/css/readthedocs-doc-embed.css',
             '_static/css/tango_cs_theme.css',
-            '_static/css/meta_label_tango.css'
+            '_static/css/meta_label_tango.css',
+            '_static/css/theme_overrides.css'
         ],
     }
 


### PR DESCRIPTION
Make tables fit into the page without scrolls

See: https://tango-controls.readthedocs.io/en/hdbpp-addition/development/advanced/TangoDeviceServerModel.html