### PR TITLE
Added instructions for Arch linux

### DIFF
--- a/source/installation/tango-on-linux.rst
+++ b/source/installation/tango-on-linux.rst
@@ -267,6 +267,12 @@ For example:
 
     $> sudo yum install -y python-pytango
 
+Arch
+----
+An AUR package exists `here <https://aur.archlinux.org/packages/tango/>`_
+
+Download and install it from there, or use your favourite AUR helper application to do the work for you.
+
 Video
 -----
 


### PR DESCRIPTION
Yesterday I adopted the orphaned AUR package for Tango, and so this can be used as an up to date way to install Tango on Arch linux.